### PR TITLE
repin hastexo/tutor-contrib-s3.git@v1.0.0. bump openedx-actions/tutor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # CHANGE LOG
 
-## Version 1.0.3 (2023-3-16)
+## Version 1.0.5 (2023-3-17)
+
+- repin to github.com/hastexo/tutor-contrib-s3.git@v1.0.0. After unpinning, the boto3 problem resurfaced, about
+a leading "/" appearing on OPENEDX_MEDIA_ROOT.
+- bump openedx-actions/tutor-k8s-get-secret@v1.0.0
+
+Note: tutor's treatment of this setting has varied over time.
+
+- Here it was set, with a leading "/" [tutor/templates/apps/openedx/settings/partials/common_all.py](https://github.com/overhangio/tutor/blob/ca04b245f3a0f7b44e0ab4fb9da9e100e6c9b9d9/tutor/templates/apps/openedx/settings/partials/common_all.py)
+- Whereas more recently in [version v15.3.2 this was removed](https://github.com/overhangio/tutor/blob/v15.3.2/tutor/templates/apps/openedx/settings/partials/common_lms.py)
+- This repo originally addressed this problem in [pr 4](https://github.com/openedx-actions/tutor-plugin-enable-s3/pull/4) by explicitly setting the value OPENEDX_MEDIA_ROOT="openedx/media/", and this had worked effectively until last night.
+
+## Version 1.0.4 (2023-3-16)
 
 - removed fork. install hastexo from main branch
 - add all input parameters from hastexo/tutor-contrib-s3
@@ -8,13 +20,13 @@
 
 ## Version 1.0.2 (2022-12-16)
 
-* revert to forked version https://github.com/lpm0073/tutor-contrib-s3.git@v14.0.2. Still getting a runtime error with the official hastexo version.
+- revert to forked version https://github.com/lpm0073/tutor-contrib-s3.git@v14.0.2. Still getting a runtime error with the official hastexo version.
 
-* bump openedx-actions/tutor-k8s-get-secret==v0.0.7
+- bump openedx-actions/tutor-k8s-get-secret==v0.0.7
 
 ## Version 1.0.1 (2022-12-16)
 
-* revert to https://github.com/hastexo/tutor-contrib-s3
+- revert to https://github.com/hastexo/tutor-contrib-s3
 
 ## Version 1.0.0 (2022-06-16)
 
@@ -24,4 +36,4 @@ General production release
 
 **Experimental. Do not use in production.**
 
-* Initial Git import
+- Initial Git import

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
 
       # This action.
       - name: Enable tutor plugin - S3
-        uses: openedx-actions/tutor-enable-plugin-s3@v1.0.4
+        uses: openedx-actions/tutor-enable-plugin-s3@v1.0.5
         with:
           namespace: openedx-prod
           s3_host: ""

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
     #
     - name: fetch S3 secrets from Kubernetes secrets
       id: get-secret
-      uses: openedx-actions/tutor-k8s-get-secret@v0.0.7
+      uses: openedx-actions/tutor-k8s-get-secret@v1.0.0
       with:
         eks-namespace: ${{ inputs.namespace }}
         eks-secret-name: s3-openedx-storage
@@ -97,7 +97,7 @@ runs:
     - name: install plugin
       id: install-plugin
       shell: bash
-      run: pip install git+https://github.com/hastexo/tutor-contrib-s3.git
+      run: pip install git+https://github.com/hastexo/tutor-contrib-s3.git@v1.0.0
 
     - name: Enable plugin
       shell: bash


### PR DESCRIPTION
…-k8s-get-secret@v1.0.0

### Type of Change
<!-- What type of change does your code introduce? -->
- [ ] New feature
- [ * ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore

### Resolves
- repin to github.com/hastexo/tutor-contrib-s3.git@v1.0.0. After unpinning, the boto3 problem resurfaced, about
a leading "/" appearing on OPENEDX_MEDIA_ROOT.
- bump openedx-actions/tutor-k8s-get-secret@v1.0.0

Note: tutor's treatment of this setting has varied over time.

- Here it was set, with a leading "/" [tutor/templates/apps/openedx/settings/partials/common_all.py](https://github.com/overhangio/tutor/blob/ca04b245f3a0f7b44e0ab4fb9da9e100e6c9b9d9/tutor/templates/apps/openedx/settings/partials/common_all.py)
- Whereas more recently in [version v15.3.2 this was removed](https://github.com/overhangio/tutor/blob/v15.3.2/tutor/templates/apps/openedx/settings/partials/common_lms.py)
- This repo originally addressed this problem in [pr 4](https://github.com/openedx-actions/tutor-plugin-enable-s3/pull/4) by explicitly setting the value OPENEDX_MEDIA_ROOT="openedx/media/", and this had worked effectively until last night.
